### PR TITLE
Add Commercial Channels page

### DIFF
--- a/source/commercial-channels.markdown
+++ b/source/commercial-channels.markdown
@@ -1,0 +1,33 @@
+---
+extends: _layouts.page
+title: "Commercial channels"
+section: content
+---
+
+## Overview
+
+ZATech does not allow commercial activity on our Slack workspace, with narrow exceptions for specific designated channels. These channels exist to provide organized spaces for commercial interactions while keeping the rest of the community focused on technical discussions and knowledge sharing.
+
+## Allowed commercial channels
+
+### Job-related channels
+
+**#jobpostings** - This channel is exclusively for advertising full-time jobs. All job postings must be submitted through [sboj.co.za](https://sboj.co.za). These positions should be standard full-time employment opportunities under the standard employment conditions in the relevant country (usually South Africa).
+
+**#freelance-jobpostings** - All other job offers belong in this channel. This includes positions for contractors, freelancers, part-time work, co-founders, interns, or if you are looking for help from another business or agency.
+
+**#jobseekers** - If you are looking for a full-time job, you can post your availability and qualifications in this channel.
+
+**#freelance-jobseekers** - If you are looking for part-time or contract work, this is the appropriate channel to advertise your availability.
+
+### Business and promotion channels
+
+**#services** - If you are advertising services that your agency or small business provides, this is the designated channel for such offerings.
+
+**#shameless-advertising** - This channel is for promoting commercial products or platforms that you want other members to use or purchase.
+
+**#show** - If you want people to try out your hobby project, side project, or something you built for non-commercial purposes, you can share it in this channel.
+
+## Important notes
+
+All commercial activity outside of these designated channels is prohibited. Please respect these guidelines to maintain the quality and focus of our community discussions. If you are unsure about where to post something, please review the channel descriptions or ask in #general for guidance.

--- a/source/index.markdown
+++ b/source/index.markdown
@@ -7,6 +7,7 @@ title: Welcome
 Hello! This is the work in progress ZATech Wiki. If you'd like to contribute please do so over on the [GitHub repo](https://github.com/zatech/zatech.github.io).
 
 ### [Frequently Asked Questions](/faqs/)
+### [Commercial channels](/commercial-channels/)
 
 ## Channel pages
 


### PR DESCRIPTION
- Created new page documenting allowed commercial channels on ZATech Slack
- Listed all commercial channels with their specific purposes
- Added link to Commercial Channels page on the index after FAQ

🤖 Generated with Claude Code